### PR TITLE
Fix condition in `__contains__` function of `DummyList`

### DIFF
--- a/nonebot_plugin_remake/utils.py
+++ b/nonebot_plugin_remake/utils.py
@@ -9,7 +9,7 @@ class DummyList(list):
         super().__init__(lst)
 
     def __contains__(self, obj: object) -> bool:
-        if isinstance(0, set):
+        if isinstance(obj, set):
             for x in self:
                 if x in obj:
                     return True


### PR DESCRIPTION
修复：if条件永远是False，include和exclude不生效